### PR TITLE
feat:  Allows the container to map the container's internal user to a…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,47 @@
 **/values.dev.yaml
 LICENSE
 README.md
+# macOS
+._*
+.DS_Store
+.LSOverride
+# Icon must end with two carriage returns (\r)
+Icon
+
+# Windows
+[Dd]esktop.ini
+ehthumbs.db
+ehthumbs_vista.db
+[Tt]humbs.db
+
+# Backups
+*.bak
+
+# Logs
+*.log
+log/
+logs/
+
+# Temporary
+*~
+*.tmp
+*.temp
+tmp/
+temp/
+
+# Vim
+.netrwhist
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]*.un~
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+
+export/
+.env
+.vscode/
+.secrets
+docker-compose.prod.yml
+docker-compose.*.yml

--- a/bw_export.sh
+++ b/bw_export.sh
@@ -1,4 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#  _                                             _   
+# | |____      __      _____  ___ __   ___  _ __| |_ 
+# | '_ \ \ /\ / /____ / _ \ \/ / '_ \ / _ \| '__| __|
+# | |_) \ V  V /_____|  __/>  <| |_) | (_) | |  | |_ 
+# |_.__/ \_/\_/       \___/_/\_\ .__/ \___/|_|   \__|
+#                              |_|                   
 # Bitwarden CLI Vault Export Script
 # Author: 0netx based on David H (@dh024)
 #  
@@ -21,7 +27,6 @@ UCyan='\033[4;36m'        # Cyan
 UWhite='\033[4;37m'       # White
 
 echo Starting ...
-
 #Set locations to save export files
 if [[ -z "${OUTPUT_PATH}" ]]; then
     echo -e "\n${Cyan}Info: OUTPUT_PATH enviroment not provided. Using default value: /var/data"
@@ -121,11 +126,11 @@ fi
 
 #Set Organization ID (if applicable)
 if [[ -z "${BW_ORGANIZATIONS_LIST}" ]]; then
-    echo -e "\n${Yellow} BW_ORGANIZATIONS_LIST enviroment not provided. All detected organizations will be exported. "
-    echo -n "If you want to make a backup of specific organizations, set one or more organizations separated by comma"
-    echo -n "To obtain your organization_id value, open a terminal and type:"
-    echo "bw login #(follow the prompts); bw list organizations | jq -r '.[0] | .id'"
-    echo "Example: cada13d7-5418-37ed-981b-be822121c593,cada13d7-5418-37ed-981b-be82219879878979,cada13d7-5418-37ed-981b-be822121c5435"
+    echo -e "\n${Cyan} BW_ORGANIZATIONS_LIST enviroment not provided. All detected organizations will be exported. "
+    echo -e "${Cyan} If you want to make a backup of specific organizations, set one or more organizations separated by comma"
+    echo -e "${Cyan} To obtain your organization_id value, open a terminal and type:"
+    echo -e "${Cyan}       bw login #(follow the prompts); bw list organizations | jq -r '.[0] | .id'"
+    echo -e "${Cyan}       Example: cada13d7-5418-37ed-981b-be822121c593,cada13d7-5418-37ed-981b-be82219879878979,cada13d7-5418-37ed-981b-be822121c5435"
 else
 	organization_list="${BW_ORGANIZATIONS_LIST}"
 fi
@@ -166,7 +171,7 @@ echo
 if [[ $bw_url_server != "" ]]
 then 
     echo "Setting custom server..."
-    bw config server $bw_url_server
+    bw config server $bw_url_server --quiet --nointeraction
     echo
 fi
 
@@ -177,7 +182,7 @@ BW_CLIENTSECRET=$client_secret
 if [[ $(bw status | jq -r .status) == "unauthenticated" ]]
 then 
     echo "Performing login..."
-    bw login --apikey --method 0 
+    bw login --apikey --method 0   --quiet --nointeraction
 fi
 if [[ $(bw status | jq -r .status) == "unauthenticated" ]]
 then 
@@ -193,26 +198,19 @@ session_key=$(bw unlock $bw_password --raw)
 if [[ $session_key == "" ]]
 then 
     echo -e "\n${IYellow}ERROR: Failed to authenticate."
-    echo
     exit 1
 else
     echo "Login successful."
-    echo
 fi
-
 #Export the session key as an env variable (needed by BW CLI)
 export BW_SESSION="$session_key" 
-
 echo
 
 #Check if the user has decided to enter a password or save unencrypted
 if [[ $password1 == "" ]]
 then 
-
     echo -e "\n${IYellow}WARNING! Your vault contents will be saved to an unencrypted file."   
     echo "WARNING! Your vault contents will be saved to an unencrypted file."     
-
-
 else
     echo -e "\n${Cyan}Info: Password for encrypted export has been provided."   
 fi
@@ -290,7 +288,6 @@ fi
 echo
 echo "Vault export complete."
 
-
 # 4. Report items in the Trash (cannot be exported)
 trash_count=$(bw list items --trash | jq -r '. | length')
 
@@ -300,8 +297,6 @@ then
     echo -e "\n${Cyan}Info: You have $trash_count items in the trash that cannot be exported."
 
 fi
-
-
 
 echo
 bw lock 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ services:
     container_name: bw-export
     image: bw-export
     volumes:
-      - ./export:/var
+      - ./export:/var/data
+      - ./export:/var/attachment
     environment:
       - BW_CLIENTID=<CLIENT ID FROM BITWARDEN API>
       - BW_CLIENTSECRET=<CLIENT SECRET FROM BITWARDEN API>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+/etc/cont-init.d/10-adduser
+su bitwarden -c /app/bw_export.sh 

--- a/root/etc/cont-init.d/10-adduser
+++ b/root/etc/cont-init.d/10-adduser
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+PUID=${PUID:-0}
+PGID=${PGID:-0}
+
+# GUID between 1-99 are typically reserved for system use, so we warn the user
+if [[ "$PUID" -lt 100 && "$PUID" -ne 0 ]]; then
+    echo "The provided PGID is below 100. This is typically reserved for system use and may cause unexpected behavior."
+fi
+
+groupmod -o -g "$PGID" bitwarden
+usermod -o -u "$PUID" bitwarden
+
+echo " _                                             _   ";
+echo "| |____      __      _____  ___ __   ___  _ __| |_ ";
+echo "| '_ \ \ /\ / /____ / _ \ \/ / '_ \ / _ \| '__| __|";
+echo "| |_) \ V  V /_____|  __/>  <| |_) | (_) | |  | |_ ";
+echo "|_.__/ \_/\_/       \___/_/\_\ .__/ \___/|_|   \__|";
+echo "                             |_|                   ";
+echo '
+-------------------------------------
+GID/UID
+-------------------------------------'
+echo "
+User uid:    $(id -u bitwarden)
+User gid:    $(id -g bitwarden)
+-------------------------------------
+"
+chown -R  bitwarden:bitwarden /app
+chown -R  bitwarden:bitwarden /var/data
+chown -R  bitwarden:bitwarden /var/attachment


### PR DESCRIPTION
… user on host machine with PUID and PGUID


Using the `PUID` and `PGID` allows our containers to map the container's internal user to a user on the host machine. All of our containers use this method of user mapping and should be applied accordingly.

## Using the variables

When creating a container from one of our images, ensure you use the `-e PUID` and `-e PGID` options in your docker command:

```shell
docker create --name=beets -e PUID=1000 -e PGID=1000 linuxserver/beets
```

Or, if you use `docker-compose`, add them to the `environment:` section:

```yaml
environment:
  - PUID=1000
  - PGID=1000
```

It is most likely that you will use the `id` of yourself, which can be obtained by running the command below. The two values you will be interested in are the `uid` and `gid`.

```shell
id $user
```