### PR TITLE
Release v1.9

### DIFF
--- a/.github/workflows/docker-publishhub-dev.yml
+++ b/.github/workflows/docker-publishhub-dev.yml
@@ -30,4 +30,4 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: 0netx/bw-export:beta, ${{ steps.bitwardencli.outputs.release }}
+          tags: 0netx/bw-export:beta, 0netx/bw-export:${{ steps.bitwardencli.outputs.release }}

--- a/.github/workflows/docker-publishhub-dev.yml
+++ b/.github/workflows/docker-publishhub-dev.yml
@@ -7,6 +7,12 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - id: bitwardencli
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          owner: bitwarden
+          repo: clients
+          excludes: prerelease, draft      
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -24,4 +30,4 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: 0netx/bw-export:beta
+          tags: 0netx/bw-export:beta, ${{ steps.bitwardencli.outputs.release }}

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ export/
 docker-compose.prod.yml
 docker-compose.*.yml
 .infisical.json
+.vs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
 LABEL description="Bitwarden exporter docker container"
-LABEL version="1.2"
+LABEL version="1.9" 
 
 # Create a volume for storing vault exporting data
 VOLUME /var/data
@@ -32,8 +32,9 @@ RUN wget $(wget -q -O - https://api.github.com/repos/containrrr/shoutrrr/release
 RUN tar -xf shoutrrr_linux_amd64.tar.gz && \
         chmod +x shoutrrr
         
-# Installing last version of Bitwarden CLI
-ADD https://vault.bitwarden.com/download/?app=cli&platform=linux /tmp/bw.zip
+# Installing BW_CLI_VERSION version of Bitwarden CLI
+ENV BW_CLI_VERSION="2025.11.0"
+ADD https://github.com/bitwarden/clients/releases/download/cli-v${BW_CLI_VERSION}/bw-linux-${BW_CLI_VERSION}.zip /tmp/bw.zip
 
 # Copy script
 COPY bw_export.sh /app/bw_export.sh 


### PR DESCRIPTION
## ⚠️ Bitwarden CLI version pinned to `2025.11.0`

Starting from version `2025.12.0`, the official Bitwarden CLI introduced a breaking change that expects `KDF/userDecryptionOptions` fields in the API key authentication response — fields that current versions of Vaultwarden do not return, causing the following error during login:

```
User Decryption Options are required for client initialization
```

This issue affects **any Vaultwarden instance** that has not yet implemented support for these new fields. Version `2025.11.0` is the **last fully compatible CLI version** with Vaultwarden.

For this reason, the image no longer downloads the `latest` CLI version from `vault.bitwarden.com` but instead **explicitly pins version `2025.11.0`** from GitHub Releases, ensuring reproducible and stable behavior regardless of when the image is built.

Reference: [[dani-garcia/vaultwarden#6729](https://github.com/dani-garcia/vaultwarden/issues/6729)](https://github.com/dani-garcia/vaultwarden/issues/6729)

> **Note:** Once Vaultwarden releases a version with full `userDecryptionOptions` support, updating `ENV BW_CLI_VERSION` in the `Dockerfile` to the corresponding CLI version will be sufficient to upgrade.
